### PR TITLE
Add quiz find by code endpoint

### DIFF
--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -21,6 +21,12 @@ class QuizzesController < ApplicationController
     end
   end
 
+  def find_by_code
+    @quiz = Quiz.find_by(code: params["code"])
+
+    render :json => @quiz
+  end
+
   def quiz_params
     params.require(:quiz).permit(
       :user_id,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
   resources :users
   resources :quizzes
+
+  match 'quiz' => 'quizzes#find_by_code', :via => :get
+
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
O objetivo deste PR é permitir que seja possível realizar requisições GET passando como parâmetro o `code` de um Quiz. Isso possibilita que a aplicação Unity consiga receber as informações do Quiz especificado por um código passado como parâmetro.

Para isso, aplicação Unity deve fazer um requisição `GET URL/quiz` com o seguinte `body`: 
```
{
   "code": "Código do quiz"
}
```