### PR TITLE
Return questions number to 5

### DIFF
--- a/app/views/quizzes/new.html.erb
+++ b/app/views/quizzes/new.html.erb
@@ -5,7 +5,7 @@
     <%= @quiz.errors.full_messages.first if @quiz.errors.any? %>
     <%= form.text_field :title, placeholder: 'Título do quiz', class:'form-control' %>
 
-    <% 15.times { -%>
+    <% 5.times { -%>
       <%= render "questions/question", form: form %>
     <% } %>
 


### PR DESCRIPTION
Esse PR retorna o número de questões na tela de criação de quiz para 5. Essa alteração é provisória e foi necessária para questões de testes com o usuário.